### PR TITLE
Add Version class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,10 @@
         "files": [
             "vendor/phpunit/phpunit/src/Framework/Assert/Functions.php"
         ]
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.3.x-dev"
+        }
     }
 }

--- a/src/Zenaton/v1/Version.php
+++ b/src/Zenaton/v1/Version.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Zenaton;
+
+/**
+ * Class to store and retrieve the version of the Zenaton library.
+ *
+ * @since 0.3
+ * @internal Used by the Zenaton agent. Should not be called by user code.
+ */
+final class Version
+{
+    const FULL = '0.3.0-DEV';
+    const ID = 00300;
+    const MAJOR = 0;
+    const MINOR = 3;
+    const PATCH = 0;
+    const EXTRA = 'DEV';
+}


### PR DESCRIPTION
Slightly different from the RFC: I thought having the word `VERSION` on every constant was superfluous since the class is already named Version.