### PR TITLE
Make Client properly encode parameters in query string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
+* `Client` now properly encode parameters sent in query strings.
+
 ### Deprecated
 
 ### Removed


### PR DESCRIPTION
### Summary

This PR ensures parameters sent in query string are properly encoded by the `Client` class.
This fixes the inability to kill workflows having special characters in their id.

### Safety check

| Q                         | A
| ------------------------- | ---
| Type                      | bugfix
| Related issues            | closes #21 
| Code covered with tests?  | yes
| Changelog updated?        | yes
| Documentation updated?    | no
