### PR TITLE
Fix namespace shadowing issue with php 5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Fixed
 
 * `Client` now properly encode parameters sent in query strings.
+* `Zenaton\Workflow\Version` class is now aliased to avoid namespace shadowing bug in PHP 5.6. See https://bugs.php.net/bug.php?id=66862.
 
 ### Deprecated
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,7 +4,7 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          failOnRisky="true"
          failOnWarning="true"
 >

--- a/src/Zenaton/v1/Client.php
+++ b/src/Zenaton/v1/Client.php
@@ -13,7 +13,7 @@ use Zenaton\Services\Http;
 use Zenaton\Services\Properties;
 use Zenaton\Services\Serializer;
 use Zenaton\Traits\SingletonTrait;
-use Zenaton\Workflows\Version;
+use Zenaton\Workflows\Version as VersionedWorkflow; // Alias is required because of a bug in PHP 5.6 namespace shadowing. See https://bugs.php.net/bug.php?id=66862.
 
 class Client
 {
@@ -174,7 +174,7 @@ class Client
     {
         $canonical = null;
         // if $flow is a versionned workflow
-        if ($flow instanceof Version) {
+        if ($flow instanceof VersionedWorkflow) {
             // store canonical name
             $canonical = get_class($flow);
             // replace by true current implementation

--- a/tests/Zenaton/v1/ClientTest.php
+++ b/tests/Zenaton/v1/ClientTest.php
@@ -11,7 +11,7 @@ use Zenaton\Test\Injector;
 use Zenaton\Test\Mock\Event\DummyEvent;
 use Zenaton\Test\Mock\Workflow\NullWorkflow;
 use Zenaton\Test\SingletonTesting;
-use Zenaton\Workflows\Version;
+use Zenaton\Workflows\Version as VersionedWorkflow; // Alias is required because of a bug in PHP 5.6 namespace shadowing. See https://bugs.php.net/bug.php?id=66862.
 
 final class ClientTest extends TestCase
 {
@@ -81,7 +81,7 @@ final class ClientTest extends TestCase
         ;
 
         $workflow = $this
-            ->getMockBuilder(Version::class)
+            ->getMockBuilder(VersionedWorkflow::class)
             ->setMethods([
                 'versions',
             ])

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+
+require __DIR__.'/../vendor/autoload.php';
+
+// Trigger autoloading of `Zenaton\Version` class.
+// This is needed because there is a bug related to namespace shadowing in PHP 5.6 (https://bugs.php.net/bug.php?id=66862)
+// that will cause fatal errors when the agent library will use the `Zenaton\Version` class.
+// Making sure this class is autoloaded at the beginning of the test suite kind of simulate the agent behavior.
+\Zenaton\Version::ID;


### PR DESCRIPTION
Well ... It's totally WTF but in summary:

There is a bug in PHP 5.6 related to namespace shadowing: https://bugs.php.net/bug.php?id=66862.
This bugs appears or not depending on the order in which files are loaded.
Because we use autoloading, we do not control the loading order of files. Also, we don't control the order in which phpunit runs tests, which influences the loading order of files.
That's why we did notice this bug only in the agent library test suite, which is loading files in a different order.

I use a bootstrap file for phpunit to force loading of the `Zenaton\Version` class before any other code in order to reproduce the issue using this repository only. 
This cause the fatal error we can see in https://github.com/zenaton/agent/pull/182:

```
Fatal error: Cannot use Zenaton\Workflows\Version as Version because the name is already in use in /home/circleci/repo/worker/priv/php/vendor/zenaton/zenaton-php/src/Zenaton/v1/Client.php on line 16

Call Stack:
    0.0001     248192   1. {main}() /home/circleci/repo/worker/priv/php/vendor/phpunit/phpunit/phpunit:0
    0.0065    1566984   2. PHPUnit_TextUI_Command::main() /home/circleci/repo/worker/priv/php/vendor/phpunit/phpunit/phpunit:52
    0.0065    1567744   3. PHPUnit_TextUI_Command->run() /home/circleci/repo/worker/priv/php/vendor/phpunit/phpunit/src/TextUI/Command.php:116
    0.0365    5982336   4. PHPUnit_TextUI_TestRunner->doRun() /home/circleci/repo/worker/priv/php/vendor/phpunit/phpunit/src/TextUI/Command.php:186
    0.0480    6544120   5. PHPUnit_Framework_TestSuite->run() /home/circleci/repo/worker/priv/php/vendor/phpunit/phpunit/src/TextUI/TestRunner.php:517
    0.3648   13466040   6. PHPUnit_Framework_TestSuite->run() /home/circleci/repo/worker/priv/php/vendor/phpunit/phpunit/src/Framework/TestSuite.php:733
    0.4154   14049024   7. PHPUnit_Framework_TestCase->run() /home/circleci/repo/worker/priv/php/vendor/phpunit/phpunit/src/Framework/TestSuite.php:733
    0.4154   14049024   8. PHPUnit_Framework_TestResult->run() /home/circleci/repo/worker/priv/php/vendor/phpunit/phpunit/src/Framework/TestCase.php:868
    0.4162   14050640   9. PHPUnit_Framework_TestCase->runBare() /home/circleci/repo/worker/priv/php/vendor/phpunit/phpunit/src/Framework/TestResult.php:686
    0.4168   14064192  10. PHPUnit_Framework_TestCase->runTest() /home/circleci/repo/worker/priv/php/vendor/phpunit/phpunit/src/Framework/TestCase.php:913
    0.4168   14064984  11. ReflectionMethod->invokeArgs() /home/circleci/repo/worker/priv/php/vendor/phpunit/phpunit/src/Framework/TestCase.php:1062
    0.4168   14065208  12. Zenaton\Worker\MicroServerTest->testAskJob() /home/circleci/repo/worker/priv/php/vendor/phpunit/phpunit/src/Framework/TestCase.php:1062
    0.4206   14091048  13. Zenaton\Worker\MicroServer->askJob() /home/circleci/repo/worker/priv/php/tests/Zenaton/Worker/v1/MicroServerTest.php:116
    0.4206   14091552  14. Zenaton\Worker\MicroServer->getWorkerUrl() /home/circleci/repo/worker/priv/php/src/Zenaton/Worker/v1/MicroServer.php:91
    0.4210   14094240  15. spl_autoload_call() /home/circleci/repo/worker/priv/php/src/Zenaton/Worker/v1/MicroServer.php:278
    0.4210   14094288  16. Composer\Autoload\ClassLoader->loadClass() /home/circleci/repo/worker/priv/php/src/Zenaton/Worker/v1/MicroServer.php:278
    0.4211   14094456  17. Composer\Autoload\includeFile() /home/circleci/repo/worker/priv/php/vendor/composer/ClassLoader.php:322
```

To fix that, I needed to alias `Zenaton\Workflows\Version` to something else to avoid the bug.