### PR TITLE
Find workflow now throws an exception when API returns an error

### DIFF
--- a/src/Zenaton/Exceptions/ApiException.php
+++ b/src/Zenaton/Exceptions/ApiException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Zenaton\Exceptions;
+
+/**
+ * Exception thrown when a response coming from the API is not what was expected.
+ */
+class ApiException extends ZenatonException
+{
+    /**
+     * Creates a new instance of the exception when an unexpected status code was received.
+     *
+     * @param int $code
+     *
+     * @return \Zenaton\Exceptions\ApiException
+     */
+    public static function unexpectedStatusCode($code)
+    {
+        return new static("The API responded with an unexpected status code: {$code}.");
+    }
+}


### PR DESCRIPTION
Before this change, `Client::findWorkflow()` was returning `null` for
status code that was returned by the API.
Now, when the status code is 404, this method returns `null`.
When the status code is 4xx or 5xx, but not 404, it will throw an
exception.
Otherwise, it will attempt to unserialize the response that was
received.