### PR TITLE
Fix serialization of objects implementing Traversable interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
-* Fixed an issue with the serializer not serializing private properties defined in parent classes of the object to serialize. (#33) 
+* Fixed an issue with the serializer not serializing private properties defined in parent classes of the object to serialize. (#33)
+* Fixed an issue with the serializer adding extra properties to objects implementing `Traversable` interface. 
 
 ### Security
 

--- a/src/Zenaton/v1/Services/Properties.php
+++ b/src/Zenaton/v1/Services/Properties.php
@@ -45,10 +45,12 @@ class Properties
             }
         }
 
-        // non-declared public variables
-        foreach ($clone as $key => $value) {
-            if (!isset($properties[$key]) && (!isset($valid) || in_array($key, $valid))) {
-                $properties[$key] = $value;
+        // non-declared public variables. Only if object does not implement \Traversable, because otherwise it can iterate things that are not properties
+        if (!($clone instanceof \Traversable)) {
+            foreach ($clone as $key => $value) {
+                if (!isset($properties[$key]) && (!isset($valid) || in_array($key, $valid))) {
+                    $properties[$key] = $value;
+                }
             }
         }
 

--- a/tests/Zenaton/v1/Services/SerializerTest.php
+++ b/tests/Zenaton/v1/Services/SerializerTest.php
@@ -166,6 +166,8 @@ final class SerializerTest extends TestCase
         ];
         // Objects inheriting other objects
         yield [new ChildClass(), '{"o":"@zenaton#0","s":[{"n":"Zenaton\\\\Services\\\\ChildClass","p":{"grandParentProperty":"zenaton","zenaton":"is dope","parentProperty":21,"parentConstructorDefinedProperty":22,"parentOverridableProperty":false,"childProperty":42,"childConstructorDefinedProperty":43}}]}'];
+        // Objects implementing Traversable
+        yield [new SimpleCollection(), '{"o":"@zenaton#0","s":[{"n":"Zenaton\\\\Services\\\\SimpleCollection","p":[]}]}'];
     }
 
     public function testEncodeAResourceMustThrowAnException()
@@ -382,6 +384,16 @@ final class SerializerTest extends TestCase
             static::assertAttributeSame(42, 'childProperty', $actual);
             static::assertAttributeSame(43, 'childConstructorDefinedProperty', $actual);
         }, '{"o":"@zenaton#0","s":[{"n":"Zenaton\\\\Services\\\\ChildClass","p":{"grandParentProperty":"zenaton","zenaton":"is dope","parentProperty":21,"parentConstructorDefinedProperty":22,"parentOverridableProperty":false,"childProperty":42,"childConstructorDefinedProperty":43}}]}'];
+
+        // Objects implementing Traversable
+        yield [function ($actual) {
+            static::assertInstanceOf(SimpleCollection::class, $actual);
+            $items = [];
+            foreach ($actual as $item) {
+                $items[] = $item;
+            }
+            static::assertEquals(['z', 'e', 'n', 'a', 't', 'o', 'n'], $items);
+        }, '{"o":"@zenaton#0","s":[{"n":"Zenaton\\\\Services\\\\SimpleCollection","p":[]}]}'];
     }
 
     public function testDecodeStringContainingWrongKeyThrowsAnException()
@@ -453,5 +465,13 @@ class ChildClass extends ParentClass
 
         $this->childConstructorDefinedProperty = 43;
         $this->parentOverridableProperty = false;
+    }
+}
+
+class SimpleCollection implements \IteratorAggregate
+{
+    public function getIterator()
+    {
+        return new \ArrayIterator(['z', 'e', 'n', 'a', 't', 'o', 'n']);
     }
 }


### PR DESCRIPTION
Consider the following class:

```php
class SimpleCollection implements \IteratorAggregate
{
    public function getIterator()
    {
        return new \ArrayIterator(['z', 'e', 'n', 'a', 't', 'o', 'n']);
    }
}
```

Without the changes from this pull request, the result of serializing an instance of this class is `{"o":"@zenaton#0","s":[{"n":"Zenaton\\Services\\SimpleCollection","p":["z","e","n","a","t","o","n"]}]}`.

This is wrong, because the serializer thinks there are properties named "z", "e", "n", "a", "t", "o" and "n" inside this object. But the class definition shows that there are no such properties.

This PR changes the `Properties` class to avoid doing a `foreach` on instances of classes implementing the `Traversable` interface, because we cannot know if iteration will be on properties or not.