### PR TITLE
Change serialization of resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 
+* Serialization of resources now results in the integer `0` instead of throwing
+  an exception in order to be consistent with the behavior of the PHP serialize
+  function.
+
 ### Deprecated
 
 ### Removed

--- a/src/Zenaton/v1/Services/Serializer.php
+++ b/src/Zenaton/v1/Services/Serializer.php
@@ -48,7 +48,8 @@ class Serializer
         } elseif (is_array($data)) {
             $value[self::KEY_ARRAY] = $this->encodeArray($data);
         } elseif ($this->isResource($data)) {
-            $this->throwResourceException();
+            // Same behavior as the PHP serialize function: resources are serialized as the integer `0`.
+            $value[self::KEY_DATA] = 0;
         } else {
             $value[self::KEY_DATA] = $data;
         }
@@ -82,11 +83,6 @@ class Serializer
             return $array[self::KEY_DATA];
         }
         throw new UnexpectedValueException('Unknown key in: '.$json);
-    }
-
-    protected function throwResourceException()
-    {
-        throw new UnexpectedValueException('You are trying to serialize an object containing a Resource (a turn around would be to use __sleep and __wakeup methods to remove and restore this Resource)');
     }
 
     protected function isObjectId($s)
@@ -142,7 +138,8 @@ class Serializer
             } elseif (is_array($value)) {
                 $array[$key] = $this->encodeArray($value);
             } elseif ($this->isResource($value)) {
-                $this->throwResourceException();
+                // Same behavior as the PHP serialize function: resources are serialized as the integer `0`.
+                $array[$key] = 0;
             } else {
                 $array[$key] = $value;
             }

--- a/tests/Zenaton/v1/Services/SerializerTest.php
+++ b/tests/Zenaton/v1/Services/SerializerTest.php
@@ -87,6 +87,10 @@ final class SerializerTest extends TestCase
             return 'Zenaton';
         };
         yield [[$closure, $closure], '{"a":["@zenaton#0","@zenaton#0"],"s":['.$serializeClosure($closure).']}'];
+        // Array containing a resource
+        $resource = fopen(__FILE__, 'r');
+        yield [[$resource], '{"a":[0],"s":[]}'];
+        fclose($resource);
         // Objects
         yield [new \DateTime('2018-09-05 11:33:00'), '{"o":"@zenaton#0","s":[{"n":"DateTime","p":{"date":"2018-09-05 11:33:00.000000","timezone_type":3,"timezone":"UTC"}}]}'];
         $object = new \stdClass();
@@ -168,35 +172,22 @@ final class SerializerTest extends TestCase
         yield [new ChildClass(), '{"o":"@zenaton#0","s":[{"n":"Zenaton\\\\Services\\\\ChildClass","p":{"grandParentProperty":"zenaton","zenaton":"is dope","parentProperty":21,"parentConstructorDefinedProperty":22,"parentOverridableProperty":false,"childProperty":42,"childConstructorDefinedProperty":43}}]}'];
         // Objects implementing Traversable
         yield [new SimpleCollection(), '{"o":"@zenaton#0","s":[{"n":"Zenaton\\\\Services\\\\SimpleCollection","p":[]}]}'];
+        // Objects containing a resource
+        $object = new C1();
+        $object->name = fopen(__FILE__, 'r');
+        yield [$object, '{"o":"@zenaton#0","s":[{"n":"Zenaton\\\\Services\\\\C1","p":{"name":0,"c2":null}}]}'];
+        fclose($object->name);
     }
 
-    public function testEncodeAResourceMustThrowAnException()
+    public function testEncodeAResourceReturnsSerializationOfIntegerZero()
     {
-        $this->expectException(\UnexpectedValueException::class);
-
         $handle = fopen(__FILE__, 'r');
         if ($handle === false) {
             static::fail('Cannot open file the current file using read access.');
         }
 
         try {
-            $this->serializer->encode($handle);
-        } finally {
-            fclose($handle);
-        }
-    }
-
-    public function testEncodeAResourceInsideAnArrayThrowsAnException()
-    {
-        $this->expectException(\UnexpectedValueException::class);
-
-        $handle = fopen(__FILE__, 'r');
-        if ($handle === false) {
-            static::fail('Cannot open file the current file using read access.');
-        }
-
-        try {
-            $this->serializer->encode([1, 2, $handle]);
+            static::assertEquals('{"d":0,"s":[]}', $this->serializer->encode($handle));
         } finally {
             fclose($handle);
         }


### PR DESCRIPTION
Resources are now serialized using the same behavior as PHP (`0`)
instead of throwing an exception.