### PR TITLE
Remove dependency vlucas/phpdotenv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Removed
 
+- Removed dependency `vlucas/phpdotenv`.
+
 ### Fixed
 
 ### Security

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "license": "Apache-2.0",
     "require": {
         "php": ">=5.6.0",
-        "vlucas/phpdotenv": "^2.4",
         "nategood/httpful": "^0.2",
         "jeremeamia/superclosure": "^2.2",
         "cakephp/chronos": "^1.1"


### PR DESCRIPTION
If I'm not mistaken, the phpdotenv library is not used. Currently, it also prevents the library to be installed on a fresh Laravel project.

I think it's better to remove it from the library and add it in the examples repository. Also, users can choose to use a different dotenv library (and they can also choose to not use a dotenv file at all), so we shouldn't require this dependency.

Fixes #40 